### PR TITLE
Fix typo in calculator.ts

### DIFF
--- a/3.lesson/calculator/tests/calculator.ts
+++ b/3.lesson/calculator/tests/calculator.ts
@@ -32,7 +32,7 @@ describe("calculator", () => {
       }
     ).signers([calculatorPair, signerPair]).rpc()
 
-    //We fecth the account and read if the string is actually in the account
+    //We fetch the account and read if the string is actually in the account
     const account = await program.account.calculator.fetch(calculatorPair.publicKey)
     expect(account.greeting).to.eql(text)
   });


### PR DESCRIPTION
Corrected typo in comment: `fecth` shall be `fetch`.