### PR TITLE
Added missing semicolon and Ok(()) to return Result<(), Error> instead of ()

### DIFF
--- a/4.lesson/README.md
+++ b/4.lesson/README.md
@@ -121,7 +121,8 @@ mod puppet_master {
         // Create a CPI context with the program and accounts to call.
         let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
         // Perform the CPI call to set data on the puppet account.
-        let result = puppet::cpi::set_data(cpi_ctx, data)
+        let result = puppet::cpi::set_data(cpi_ctx, data)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This was giving an error during compilation:

error[E0308]: mismatched types
  --> programs/puppet_master/src/lib.rs:14:66
   |
14 |     pub fn pull_strings(ctx: Context<PullStrings>, data: u64) -> Result<()> {
   |            ------------                                          ^^^^^^^^^^ expected `Result<(), Error>`, found `()`
   |            |
   |            implicitly returns `()` as its body has no tail or `return` expression
   |
   = note:   expected enum `std::result::Result<(), anchor_lang::error::Error>`
           found unit type `()`