### PR TITLE
fix: lesson 1 hello world builds

### DIFF
--- a/1.lesson/hello_world/programs/hello_world/src/lib.rs
+++ b/1.lesson/hello_world/programs/hello_world/src/lib.rs
@@ -17,14 +17,11 @@ pub mod hello_world {
 pub struct Initialize<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
+    /// TIP: space = account discriminator + HelloWorldAccount::INIT_SPACE
+    /// Use InitSpace macro to calculate the space instead of doing it manually
     #[account(
         init,
         payer = signer,
-        /// TIP: 
-        /// 
-        /// space = account discriminator + HelloWorldAccount::INIT_SPACE
-        /// 
-        /// Use InitSpace macro to calculate the space instead of doing it manually
         space = 8 + HelloWorldAccount::INIT_SPACE,
     )]
     pub hello_world_account: Account<'info, HelloWorldAccount>,


### PR DESCRIPTION
/// comments inside macro parameters are not valid Rust as they cause parsing errors.

I have moved the comment above the macro.